### PR TITLE
feat: Add Terraform configuration for AWS S3 bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,36 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# Ignore lock files
+.terraform.lock.hcl

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,32 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_s3_bucket" "existing_bucket" {
+  bucket = var.bucket_name
+
+  force_destroy = false
+
+  tags = {
+    Name        = var.bucket_name
+    Environment = "Production"
+    ManagedBy   = "Terraform"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "existing_bucket" {
+  bucket = aws_s3_bucket.existing_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# 버킷 버저닝 설정. 필요에 따라 조정하세요.
+resource "aws_s3_bucket_versioning" "existing_bucket" {
+  bucket = aws_s3_bucket.existing_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_name" {
+  description = "Name of the S3 bucket"
+  value       = aws_s3_bucket.existing_bucket.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the S3 bucket"
+  value       = aws_s3_bucket.existing_bucket.arn
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,0 +1,2 @@
+aws_region  = "ap-northeast-2"
+bucket_name = "calda-bucket"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,11 @@
+variable "aws_region" {
+  description = "AWS region where the S3 bucket is located"
+  type        = string
+  default     = "ap-northeast-2"
+}
+
+variable "bucket_name" {
+  description = "Name of the existing S3 bucket"
+  type        = string
+  default     = "calda-bucket"
+}


### PR DESCRIPTION
This commit adds the Terraform configuration files for creating an AWS S3 bucket. The `main.tf` file defines the AWS provider and creates the S3 bucket resource with the specified bucket name. The `outputs.tf` file defines the output variables for the bucket name and ARN. The `terraform.tfvars` file contains the default values for the AWS region and bucket name variables. The `variables.tf` file defines the input variables for the AWS region and bucket name. These configurations enable the creation of an S3 bucket with the desired settings.